### PR TITLE
Show more days

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -5,7 +5,7 @@ class BookingsController < ApplicationController
     @date = params[:id].nil? ? Date.today+1 : Date.today + params[:id].to_i
 
     days = t(:"date.abbr_day_names")
-    @dates = (0..2).map do |id|
+    @dates = (0..4).map do |id|
       day = Date.today + id
 
       [ id , days[day.wday], day==@date ]


### PR DESCRIPTION
I like to plan ahead and want to see more days than just today + 2 days.

Warning: This is not tested, but I checked on the live app that I can manually show later days by just increasing the id on the `/bookings/2` url.